### PR TITLE
cerbot-register should not depend on dialog

### DIFF
--- a/templates/bin/certbot-register.in
+++ b/templates/bin/certbot-register.in
@@ -6,4 +6,5 @@ exec ${buildout:bin-directory}/certbot \
         --work-dir=${buildout:parts-directory}/certbot/lib \
         --logs-dir=${buildout:parts-directory}/certbot/log \
         --webroot --webroot-path=${buildout:parts-directory}/certbot/web \
+        --text \
         register


### PR DESCRIPTION
Certbot depends on "dialog" by default which is used to provide a nicer interface. When invoking with the --text parameter Certbot uses a plain text line interface instead. Added this parameter drops this requirement.
